### PR TITLE
Load yaml-js using https

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
     }
   </style>
   <script src='jquery.js'></script>
-  <script src='http://rawgithub.com/connec/yaml-js/master/yaml.min.js'></script>
+  <script src='https://rawgithub.com/connec/yaml-js/master/yaml.min.js'></script>
   <script>
   (function() {
     var resize = function() {


### PR DESCRIPTION
The example / playground is currently not working as the page is loaded with https, but the library is not.

Firefox:
> Blocked loading mixed active content “http://rawgithub.com/connec/yaml-js/master/yaml.min.js”

Chrome:
> Mixed Content: The page at 'https://connec.github.io/yaml-js/' was loaded over HTTPS, but requested an insecure script 'http://rawgithub.com/connec/yaml-js/master/yaml.min.js'. This request has been blocked; the content must be served over HTTPS.