### PR TITLE
Fixed flow_style in map representer

### DIFF
--- a/lib/representer.js
+++ b/lib/representer.js
@@ -159,7 +159,7 @@
           }
           value.push([node_key, node_value]);
         }
-        if (!flow_style) {
+        if (flow_style == null) {
           node.flow_style = (ref = this.default_flow_style) != null ? ref : best_style;
         }
         return node;

--- a/src/lib/representer.coffee
+++ b/src/lib/representer.coffee
@@ -113,7 +113,7 @@ class @BaseRepresenter
         best_style = false
       value.push [ node_key, node_value ]
 
-    node.flow_style = @default_flow_style ? best_style unless flow_style
+    node.flow_style = @default_flow_style ? best_style unless flow_style?
     node
 
   ignore_aliases: (data) ->


### PR DESCRIPTION
The map representer would interpret undefined/null the same as false, resulting in the map representer always using true for flow_style regardless of what was passed in. 